### PR TITLE
Do not spoil slave log with status messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/detection/unreliable/slave/BuildStatisticListener.java
+++ b/src/main/java/org/jenkinsci/plugins/detection/unreliable/slave/BuildStatisticListener.java
@@ -48,7 +48,7 @@ public class BuildStatisticListener extends RunListener<Run>{
             Logger.getLogger(BuildStatisticListener.class.getName()).log(Level.INFO, "Unreliable slave plugin is nost set");
             return;
         }
-        listener.getLogger().println("Loading slave statistic");
+
         Result r = run.getResult();
         Computer computer = run.getExecutor().getOwner();
         SlaveBuildFailureStatistic slaveStatistic = getSlaveStatistic(computer.getDisplayName());
@@ -66,7 +66,6 @@ public class BuildStatisticListener extends RunListener<Run>{
         }
         if(r.equals(Result.SUCCESS))
             slaveStatistic.success();
-        listener.getLogger().println("Slave statistic loaded");
     }
     
     


### PR DESCRIPTION
`BuildStatisticListener` prints _Loading slave statistic_ and _Slave statistic loaded_ to console log instead of operating silently.
